### PR TITLE
chore: add relative paths to Checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphLint
 
-A linting tool for GraphQL schemas. 
+A linting tool for GraphQL schemas.
 
 This tool is meant for finding errors in your GraphQL schemas.
 It is not made for your Queries.
@@ -9,10 +9,13 @@ The purpose of this tool is
 to implement the [GraphQL Standard from Worksome](https://github.com/worksome/graphql-standards).
 
 ## Installation
+
 The tool can be installed as a composer global dependency via
+
 ```bash
 $ composer global require worksome/graphlint
 ```
+
 or via Homebrew
 
 ```bash
@@ -21,10 +24,23 @@ brew install --formula worksome/tap/graphlint
 ```
 
 ## Usage
+
 The tool can be run via
+
 ```bash
 $ graphlint path/to/schema.graphql
 ```
+
+### CI Usage with GitHub Actions
+
+With GitHub Actions, we support using the [`cs2pr`](https://github.com/staabm/annotate-pull-request-from-checkstyle)
+tool to add inline annotations to your pull requests.
+
+```bash
+graphlint --format=checkstyle path/to/schema.graphql | cs2pr
+```
+
+As we do not pass the 
 
 ## Configuration
 
@@ -65,16 +81,19 @@ The tool can have a configuration for schemas before compiling and after.
 Some libraries do not compile their schema, so for those only one of the tags should be used.
 
 ### Ignoring problems
+
 A problem can be suppressed by adding an `ignore-next-line` comment before it.
+
 ```graphql
 interface Account {
-  # @graphlint-ignore-next-line
-  id: ID
+    # @graphlint-ignore-next-line
+    id: ID
 }
 ```
 
 In some cases, it is not possible to add a comment because the schema is auto generated. For
 those cases, the error can be ignored by adding the following in the configuration file.
+
 ```php
 return function (ContainerConfigurator $config): void {
     $config->services()

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -72,7 +72,7 @@ class AnalyseCommand extends Command
             $output
         );
 
-        $configurationFile = getcwd().DIRECTORY_SEPARATOR.'graphlint.php';
+        $configurationFile = getcwd() . DIRECTORY_SEPARATOR . 'graphlint.php';
 
         if (! is_file($configurationFile) || ! is_readable($configurationFile)) {
             $style->error("Unable to find a \"graphlint.php\" configuration file in your current directory.");
@@ -98,13 +98,13 @@ class AnalyseCommand extends Command
         /** @var string $inputFormat */
         $inputFormat = $input->getOption(self::INPUT);
         $rawSchema = match ($inputFormat = InputFormat::tryFrom($inputFormat)) {
-            InputFormat::FILE => file_get_contents(getcwd().DIRECTORY_SEPARATOR.$compiledSchema),
+            InputFormat::FILE => file_get_contents(getcwd() . DIRECTORY_SEPARATOR . $compiledSchema),
             default => $compiledSchema,
         };
 
         $compiledNode = Parser::parse($rawSchema);
 
-        $compiledPath = $inputFormat === InputFormat::FILE ? getcwd().DIRECTORY_SEPARATOR.$compiledSchema : null;
+        $compiledPath = $inputFormat === InputFormat::FILE ? getcwd() . DIRECTORY_SEPARATOR . $compiledSchema : null;
 
         /** @var string $format */
         $format = $input->getOption(self::FORMAT);

--- a/src/Listeners/CheckstyleListener.php
+++ b/src/Listeners/CheckstyleListener.php
@@ -41,7 +41,7 @@ class CheckstyleListener implements GraphlintListener
         $dom = new DOMDocument('1.0', 'UTF-8');
         $checkstyles = $dom->appendChild($dom->createElement('checkstyle'));
 
-        foreach (['Compiled' => $compiledResult, 'Original' => $originalResult] as $type => $result) {
+        foreach (['Compiled' => $compiledResult, 'Original' => $originalResult] as $result) {
             /** @var AnalyserResult $result */
 
             $problems = $result->getProblemsHolder()->getProblems();

--- a/src/Listeners/CheckstyleListener.php
+++ b/src/Listeners/CheckstyleListener.php
@@ -22,6 +22,7 @@ class CheckstyleListener implements GraphlintListener
 
     public function __construct(
         private readonly SymfonyStyle $style,
+        private readonly string|null $compiledPath = null
     ) {
         if (! \extension_loaded('dom')) {
             throw new RuntimeException('Cannot generate report! `ext-dom` is not available!');
@@ -53,7 +54,7 @@ class CheckstyleListener implements GraphlintListener
             $this->hasErrors = true;
 
             foreach ($problems as $problem) {
-                $location = $problem->getNode()->loc?->source?->name;
+                $location = $this->compiledPath ?? $problem->getNode()->loc?->source?->name;
 
                 if ($location === null) {
                     throw new ShouldNotHappenException("No location on node.");
@@ -61,7 +62,7 @@ class CheckstyleListener implements GraphlintListener
 
                 /** @var DOMElement $file */
                 $file = $checkstyles->appendChild($dom->createElement('file'));
-                $file->setAttribute('name', "{$type}: {$location}");
+                $file->setAttribute('name', $location);
 
                 $error = $this->createError($dom, $problem);
                 $file->appendChild($error);


### PR DESCRIPTION
This adds relative paths when `--format=checkstyle` is used with a file input. If `--input` is not `file`, it will display `GraphQL request` as before.

![Screenshot 2022-09-23 at 16 15 07](https://user-images.githubusercontent.com/1899334/191994633-bb36c666-080e-4371-9f48-746d754e7a28.png)
