### PR TITLE
feat(command): Improve error output in console command

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -37,5 +37,6 @@ return function (ContainerConfigurator $configurator) {
         '../src/Events',
         '../src/Laravel',
         '../src/InspectionDescription.php',
+        '../src/Utils/ProblemOutputGenerator.php',
     ]);
 };

--- a/src/Utils/ProblemOutputGenerator.php
+++ b/src/Utils/ProblemOutputGenerator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Graphlint\Utils;
+
+use GraphQL\Language\Token;
+use Worksome\Graphlint\ProblemDescriptor;
+use Worksome\Graphlint\ShouldNotHappenException;
+
+final readonly class ProblemOutputGenerator
+{
+    public function __construct(
+        private ProblemDescriptor $descriptor,
+        private int $index,
+        private int $surroundingContextCharacters = 100,
+    ) {
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function generate(): array
+    {
+        return [$this->title(), PHP_EOL, $this->schemaSnippet(), PHP_EOL];
+    }
+
+    private function title(): string
+    {
+        return sprintf(
+            "<bg=red;options=bold>%s  %d: %s  %s</>",
+            PHP_EOL . PHP_EOL,
+            $this->index + 1,
+            $this->descriptor->getDescription(),
+            PHP_EOL
+        );
+    }
+
+    private function schemaSnippet(): string
+    {
+        $bodyCharacters = mb_str_split($this->schemaBody());
+
+        $bodyCharacters[$this->startToken()->start] = sprintf(
+            '<fg=red>%s',
+            $bodyCharacters[$this->startToken()->start]
+        );
+        $bodyCharacters[$this->endToken()->end] = sprintf('%s</>', $bodyCharacters[$this->endToken()->end]);
+
+        $snippetStartIndex = max(0, $this->startToken()->start - $this->surroundingContextCharacters);
+        $snippetLength = $this->endToken()->end - $snippetStartIndex + $this->surroundingContextCharacters;
+
+        $snippetCharacters = array_splice($bodyCharacters, $snippetStartIndex, $snippetLength);
+
+        return sprintf('<fg=black>%s</>', implode('', $snippetCharacters));
+    }
+
+    private function startToken(): Token
+    {
+        $startToken = $this->descriptor->getNode()->loc?->startToken;
+
+        if ($startToken === null) {
+            throw new ShouldNotHappenException("No location on node.");
+        }
+
+        return $startToken;
+    }
+
+    private function endToken(): Token
+    {
+        $endToken = $this->descriptor->getNode()->loc?->endToken;
+
+        if ($endToken === null) {
+            throw new ShouldNotHappenException("No location on node.");
+        }
+
+        return $endToken;
+    }
+
+    private function schemaBody(): string
+    {
+        $body = $this->descriptor->getNode()->loc?->source?->body;
+
+        if ($body === null) {
+            throw new ShouldNotHappenException("No source on node.");
+        }
+
+        return $body;
+    }
+}


### PR DESCRIPTION
This PR alters the standard problem error output in the console to show a snippet of the GQL schema where the issue exists:

<img width="767" alt="CleanShot 2023-04-07 at 14 22 17@2x" src="https://user-images.githubusercontent.com/12202279/230616181-195fea0a-74e7-45d1-89c6-faaefc51b556.png">

Previously, errors were shown in a table, but the line and column numbers displayed gave no real useful information because of how the GQL parser works. Now, instead of showing line numbers for a computed schema, we show the line that is causing the error along with surrounding lines for context.