### PR TITLE
feat: add config builder class

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,13 @@ Create a file in the root called `graphlint.php` with the following configuratio
 ```php
 <?php declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Worksome\Graphlint\Configuration\Visitor;
+use Worksome\Graphlint\Config\GraphlintConfig;
 use Worksome\Graphlint\Inspections\CamelCaseFieldDefinitionInspection;
 
-return function (ContainerConfigurator $config): void {
-    $services = $config->services();
-
-    $services->set(CamelCaseFieldDefinitionInspection::class)
-        ->tag(Visitor::COMPILED);
-};
+return GraphlintConfig::configure()
+    ->withInspections([
+        CamelCaseFieldDefinitionInspection::class,
+    ]);
 ```
 
 To use the Worksome GraphQL standard:
@@ -67,12 +64,10 @@ To use the Worksome GraphQL standard:
 ```php
 <?php declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Worksome\Graphlint\GraphlintSet;
+use Worksome\Graphlint\Config\GraphlintConfig;
 
-return function (ContainerConfigurator $config): void {
-    $config->import(GraphlintSet::Standard->value);
-};
+return GraphlintConfig::configure()
+    ->withPreparedSets(standard: true);
 ```
 
 The tool can have a configuration for schemas before compiling and after.
@@ -93,14 +88,14 @@ In some cases, it is not possible to add a comment because the schema is auto ge
 those cases, the error can be ignored by adding the following in the configuration file.
 
 ```php
-return function (ContainerConfigurator $config): void {
-    $config->services()
-        ->set(IgnoreByNameSuppressorInspection::class)
-        ->call('configure', [
-            'TEST',
-            'AccountInput.name' // Dotted value for only applying on some fields
-        ]);
-};
+use Worksome\Graphlint\Config\GraphlintConfig;
+
+return GraphlintConfig::configure()
+    // ...
+    ->ignoring([
+        'TEST',
+        'AccountInput.name' // Dotted value for only applying on some fields
+    ]);
 ```
 
 ## Testing

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,9 +10,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Config/GraphlintConfig.php
+++ b/src/Config/GraphlintConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Graphlint\Config;
+
+use Worksome\Graphlint\Configuration\GraphlintConfigBuilder;
+
+final class GraphlintConfig
+{
+    public static function configure(): GraphlintConfigBuilder
+    {
+        return new GraphlintConfigBuilder();
+    }
+}

--- a/src/Configuration/GraphlintConfigBuilder.php
+++ b/src/Configuration/GraphlintConfigBuilder.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Graphlint\Configuration;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Worksome\Graphlint\GraphlintSet;
+use Worksome\Graphlint\Inspections\IgnoreByNameSuppressorInspection;
+use Worksome\Graphlint\Inspections\Inspection;
+
+final class GraphlintConfigBuilder
+{
+    /** @var array<GraphlintSet> */
+    private array $sets = [];
+
+    /** @var array<class-string<Inspection>> */
+    private array $inspections = [];
+
+    /** @var array<string> */
+    private array $ignored = [];
+
+    public function __invoke(ContainerConfigurator $config): void
+    {
+        $services = $config->services();
+
+        foreach ($this->sets as $set) {
+            $config->import($set->value);
+        }
+
+        foreach ($this->inspections as $inspection) {
+            $services->set($inspection)->tag(Visitor::COMPILED);
+        }
+
+        $services
+            ->set(IgnoreByNameSuppressorInspection::class)
+            ->call('configure', $this->ignored);
+    }
+
+    public function withPreparedSets(
+        bool $standard = false,
+    ): self {
+        if ($standard) {
+            $this->sets[] = GraphlintSet::Standard;
+        }
+
+        return $this;
+    }
+
+    /** @param array<class-string<Inspection>> $inspections */
+    public function withInspections(array $inspections): self
+    {
+        $this->inspections = [...$this->inspections, ...$inspections];
+
+        return $this;
+    }
+
+    /** @param array<non-empty-string> $ignored */
+    public function ignoring(array $ignored): self
+    {
+        $this->ignored = [...$this->ignored, ...$ignored];
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Closes #44

This implements a new wrapper around the `ContainerConfigurator`. In future, it would be nice to move to a custom solution, but for now this just simplifies the config.

```php
<?php declare(strict_types=1);

use Worksome\Graphlint\Config\GraphlintConfig;

return GraphlintConfig::configure()
    ->withPreparedSets(standard: true);
```